### PR TITLE
feat: update installer for auto marzban token

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Configuration is stored in `/opt/marzban-eye/.env`.
 Run as root or with sudo:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/marzban-eye/marzban-eye/main/scripts/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/marzban-eye/marzban-eye/master/scripts/install.sh | sudo bash
 ```
 
 ## Health Check

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
-# marzban-eye
+# Marzban-Eye
+
+Marzban-Eye is a lightweight FastAPI dashboard for [Marzban](https://github.com/razordeveloper/marzban) servers. It proxies the Marzban admin API and offers a simple web UI and REST interface secured with JWT authentication.
+
+## Features
+
+- Auto-manages Marzban admin token using username/password
+- User listing and basic stats proxying the Marzban API
+- Optional dashboard with local admin credentials
+- Systemd or Docker deployment
+
+## Requirements
+
+- Python 3.10+
+- Access to a running Marzban instance
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `MARZBAN_API_URL` | Base URL of Marzban API (e.g. `https://host:8000`) | — |
+| `MARZBAN_ADMIN_USERNAME` | Marzban admin username used to fetch tokens | — |
+| `MARZBAN_ADMIN_PASSWORD` | Marzban admin password | — |
+| `VERIFY_SSL` | Verify Marzban TLS certificate | `True` |
+| `MARZBAN_TIMEOUT` | HTTP timeout for Marzban requests (seconds) | `15` |
+| `TOKEN_SKEW_SECONDS` | Clock skew allowance when refreshing tokens | `30` |
+| `TOKEN_FALLBACK_TTL` | Fallback token TTL used before first refresh | `3300` |
+
+## Installation
+
+Clone the repository to `/opt/marzban-eye` and run the installer:
+
+```bash
+git clone https://github.com/marzban-eye/marzban-eye.git /opt/marzban-eye
+cd /opt/marzban-eye
+bash scripts/install.sh
+```
+
+The script prompts for:
+
+1. `MARZBAN_API_URL`
+2. `MARZBAN_ADMIN_USERNAME`
+3. `MARZBAN_ADMIN_PASSWORD`
+4. Dashboard admin username & password
+
+Configuration is stored in `/opt/marzban-eye/.env`.
+
+### Easy Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/marzban-eye/marzban-eye/main/scripts/install.sh | bash
+```
+
+## Health Check
+
+Verify the service is running:
+
+```bash
+curl -f http://localhost:9000/health
+```
+
+List users through Marzban using a freshly obtained dashboard token:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:9000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=ADMIN_USER&password=ADMIN_PASS" | jq -r '.access_token')
+curl -H "Authorization: Bearer $TOKEN" http://localhost:9000/users
+```
+
+Replace `ADMIN_USER`/`ADMIN_PASS` with the dashboard credentials you configured.
+
+## License
+
+MIT
+

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Configuration is stored in `/opt/marzban-eye/.env`.
 
 ### Easy Install
 
+Run as root or with sudo:
+
 ```bash
-curl -fsSL https://raw.githubusercontent.com/marzban-eye/marzban-eye/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/marzban-eye/marzban-eye/main/scripts/install.sh | sudo bash
 ```
 
 ## Health Check

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_URL="https://github.com/marzban-eye/marzban-eye.git"
+INSTALL_DIR="/opt/marzban-eye"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/../requirements.txt" ]; then
+  cd "$SCRIPT_DIR/.."
+else
+  if [ ! -d "$INSTALL_DIR/.git" ]; then
+    echo "==> Cloning Marzban-Eye to ${INSTALL_DIR}..."
+    sudo git clone "$REPO_URL" "$INSTALL_DIR"
+  fi
+  cd "$INSTALL_DIR"
+fi
+
 echo "==> Checking Python & venv..."
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 not found. Install Python 3.10+ and retry."; exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,9 +17,11 @@ pip install -r requirements.txt
 # نیازهای Auth و هش:
 pip install "passlib[bcrypt]" "python-jose[cryptography]" uvicorn
 
+# Gather Marzban credentials (URL + admin user/pass)
 echo
 read -rp "Marzban API URL (مثلا https://YOUR_MARZBAN_IP:443): " MARZBAN_API_URL
-read -rp "Marzban API Token: " MARZBAN_API_TOKEN
+read -rp "Marzban admin username: " MARZBAN_ADMIN_USERNAME
+read -rsp "Marzban admin password: " MARZBAN_ADMIN_PASSWORD; echo
 
 echo
 read -rp "Admin username for panel: " ADMIN_USERNAME
@@ -53,8 +55,10 @@ VERIFY_SSL=${VERIFY_SSL:-True}
 read -rp "Panel port [9000]: " PANEL_PORT
 PANEL_PORT=${PANEL_PORT:-9000}
 
-echo "==> Writing .env ..."
-cat > .env <<ENV
+ENV_FILE="/opt/marzban-eye/.env"
+mkdir -p "$(dirname "${ENV_FILE}")"
+echo "==> Writing ${ENV_FILE} ..."
+cat > "${ENV_FILE}" <<ENV
 # --- Admin login (dashboard & JWT) ---
 ADMIN_USERNAME=${ADMIN_USERNAME}
 ADMIN_PASSWORD_HASH=${ADMIN_PASSWORD_HASH}
@@ -65,13 +69,19 @@ JWT_EXPIRE_MINUTES=720
 
 # --- Marzban API ---
 MARZBAN_API_URL=${MARZBAN_API_URL}
-MARZBAN_API_TOKEN=${MARZBAN_API_TOKEN}
+MARZBAN_ADMIN_USERNAME=${MARZBAN_ADMIN_USERNAME}
+MARZBAN_ADMIN_PASSWORD=${MARZBAN_ADMIN_PASSWORD}
 VERIFY_SSL=${VERIFY_SSL}
+MARZBAN_TIMEOUT=15
+TOKEN_SKEW_SECONDS=30
+TOKEN_FALLBACK_TTL=3300
 
 # --- Server ---
 HOST=0.0.0.0
 PORT=${PANEL_PORT}
 ENV
+
+sed -i '/^MARZBAN_API_TOKEN/d;/^MARZBAN_API_KEY/d' "${ENV_FILE}" 2>/dev/null || true
 
 echo "==> Creating systemd service..."
 sudo bash -c "cat > /etc/systemd/system/marzban-eye.service <<SERVICE
@@ -90,11 +100,18 @@ User=root
 WantedBy=multi-user.target
 SERVICE"
 
-echo "==> Reloading & starting service..."
-sudo systemctl daemon-reload
-sudo systemctl enable --now marzban-eye
-sleep 1
-sudo systemctl status marzban-eye --no-pager || true
+echo "==> Applying service changes..."
+if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files | grep -q '^marzban-eye.service'; then
+  sudo systemctl daemon-reload
+  sudo systemctl restart marzban-eye
+  sleep 1
+  sudo systemctl status marzban-eye --no-pager || true
+elif command -v docker >/dev/null 2>&1 && [ -f docker-compose.yml ]; then
+  echo "Docker environment detected. Rebuild/start with:"
+  echo "  docker compose up -d --build"
+else
+  echo "Please restart the marzban-eye service manually."
+fi
 
 echo
 echo "==> Done."


### PR DESCRIPTION
## Summary
- drop manual API token prompts and use Marzban admin credentials
- refresh .env defaults and add restart logic for systemd/docker
- rewrite README with new install flow and health check

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6898cddfac0c8329bb6b036814f14207